### PR TITLE
ci: update dependency review step to use correct token and handle pull request events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,9 @@ jobs:
 
       # Step 9: Dependency Review
       - name: Dependency Review
+        if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-severity: low
+          fail-on-scopes: runtime


### PR DESCRIPTION
- Replaced `token` with `repo-token` in dependency review step.
- Added conditional to ensure step runs only for pull requests (`github.event_name == 'pull_request'`).
- Resolved warnings and errors related to missing `base_ref` and `head_ref` during push events.